### PR TITLE
change-spending-#13. Finalize average spending chart

### DIFF
--- a/src/charts/AverageMonthSpending.js
+++ b/src/charts/AverageMonthSpending.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import Chart from 'react-apexcharts';
+import { connect } from 'react-redux';
+import Paper from '@material-ui/core/Paper';
+import { arrayOf, shape, string, number } from 'prop-types';
+import { getMonthsFromTransactions } from '../utils';
+
+const AverageMonthSpending = ({ spendingByCategories, transactions }) => {
+  const numOfMonths = getMonthsFromTransactions(transactions).size;
+
+  const series = spendingByCategories.map(s => ({
+    name: s.title,
+    data: [Math.abs(s.spending) / numOfMonths]
+  }));
+
+  const options = {
+    chart: {
+      stacked: true
+    },
+    dataLabels: {
+      formatter: val => (val !== 0 ? val : '')
+    },
+    xaxis: {
+      categories: ['Average']
+    }
+  };
+
+  return (
+    <Paper>
+      <Chart series={series} options={options} type="bar" />
+    </Paper>
+  );
+};
+
+AverageMonthSpending.propTypes = {
+  spendingByCategories: arrayOf(
+    shape({
+      title: string.isRequired,
+      spending: number.isRequired
+    })
+  ).isRequired,
+  transactions: arrayOf(
+    shape({
+      date: string.isRequired,
+      amount: number.isRequired,
+      party: string.isRequired
+    })
+  ).isRequired
+};
+
+const mapStateToProps = state => ({
+  spendingByCategories: state.amountReducer.spendingByCategories,
+  transactions: state.appReducer.transactions
+});
+
+export default connect(mapStateToProps)(AverageMonthSpending);

--- a/src/charts/SpendingByMonth.js
+++ b/src/charts/SpendingByMonth.js
@@ -1,19 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { arrayOf, shape, string, object } from 'prop-types';
+import { arrayOf, shape, string, object, number } from 'prop-types';
 import Chart from 'react-apexcharts';
 import Paper from '@material-ui/core/Paper';
+import { getMonthsFromTransactions } from '../utils';
 
-const SpendingByMonth = ({ spendingByMonth }) => {
-  const months = new Set();
+const SpendingByMonth = ({ spendingByMonth, transactions }) => {
+  const months = getMonthsFromTransactions(transactions);
   let series = [];
-
-  spendingByMonth.forEach(category => {
-    const spending = category.spendingByMonth;
-    Object.keys(spending).forEach(month => {
-      months.add(month);
-    });
-  });
 
   spendingByMonth.forEach(category => {
     const spending = category.spendingByMonth;
@@ -44,6 +38,8 @@ const SpendingByMonth = ({ spendingByMonth }) => {
     }
   };
 
+  console.log('series', series);
+
   return (
     <Paper>
       <Chart options={options} series={series} type="bar" />
@@ -57,11 +53,19 @@ SpendingByMonth.propTypes = {
       title: string.isRequired,
       spendingByMonth: object.isRequired
     })
+  ).isRequired,
+  transactions: arrayOf(
+    shape({
+      date: string.isRequired,
+      amount: number.isRequired,
+      party: string.isRequired
+    })
   ).isRequired
 };
 
 const mapStateToProps = state => ({
-  spendingByMonth: state.amountReducer.spendingByMonth
+  spendingByMonth: state.amountReducer.spendingByMonth,
+  transactions: state.appReducer.transactions
 });
 
 export default connect(mapStateToProps)(SpendingByMonth);

--- a/src/pages/VisualizationPage.js
+++ b/src/pages/VisualizationPage.js
@@ -11,6 +11,7 @@ import TransactionHistory from '../charts/TransactionHistory';
 import SpendingByCategory from '../charts/SpendingByCategory';
 import Container from '../components/Container';
 import SpendingByMonth from '../charts/SpendingByMonth';
+import AverageMonthSpending from '../charts/AverageMonthSpending';
 
 const TabContainer = styled(Paper)`
   flex-grow: 1;
@@ -23,6 +24,7 @@ const PARTY_GROUPING = 2;
 const CATEGORY_GROUPING = 3;
 const SPENDING_BY_CATEGORY = 4;
 const SPENDING_BY_MONTH = 5;
+const AVERAGE_SPENDING = 6;
 
 export class VisualizationPage extends React.Component {
   state = { activeTab: TRANSACTION_HISTORY };
@@ -52,6 +54,9 @@ export class VisualizationPage extends React.Component {
     if (activeTab === SPENDING_BY_MONTH) {
       return <SpendingByMonth />;
     }
+    if (activeTab === AVERAGE_SPENDING) {
+      return <AverageMonthSpending />;
+    }
     return null;
   };
 
@@ -76,6 +81,7 @@ export class VisualizationPage extends React.Component {
             <Tab label="Categories" />
             <Tab label="Spending" />
             <Tab label="Spending by month" />
+            <Tab label="Average spending in a month" />
           </Tabs>
         </TabContainer>
         <Container>

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,14 @@ export const sumAndSpendingOfParties = (transactions, listOfParties) => {
   return { sum, spending, spendingByMonth };
 };
 
+export const getMonthsFromTransactions = transactions => {
+  const months = new Set();
+  transactions.forEach(t => {
+    months.add(moment(t.date).format('YYYY-MM'));
+  });
+  return months;
+};
+
 export const significantParties = transactions => {
   const parties = [...new Set(transactions.map(t => t.party))].map(p => ({
     title: p,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,4 +1,4 @@
-import { significantParties, sumAndSpendingOfParties } from './utils';
+import { significantParties, sumAndSpendingOfParties, getMonthsFromTransactions } from './utils';
 import { transactions, categories } from './testHelpers';
 
 describe('utils.js', () => {
@@ -55,5 +55,27 @@ describe('utils.js', () => {
 
     const result = sumAndSpendingOfParties(transacts, ['party1', 'party2', 'party3']);
     expect(result.spending).toBe(-3.5);
+  });
+
+  it(`should return correct value from ${getMonthsFromTransactions.name}`, () => {
+    const transacts = [
+      {
+        date: new Date('2018-11-17T10:39:49+00:00').toISOString()
+      },
+      {
+        date: new Date('2018-11-17T10:39:49+00:00').toISOString()
+      },
+      {
+        date: new Date('2018-12-17T10:39:49+00:00').toISOString()
+      },
+      {
+        date: new Date('2019-01-17T10:39:49+00:00').toISOString()
+      }
+    ];
+    const result = [...getMonthsFromTransactions(transacts).values()];
+    expect(result.length).toBe(3);
+    expect(result.includes('2018-11')).toBe(true);
+    expect(result.includes('2018-12')).toBe(true);
+    expect(result.includes('2019-01')).toBe(true);
   });
 });


### PR DESCRIPTION
Created a chart that shows the average spending in a month. This is done by getting all the months from the transactions, and then combining all the spending by category and then just dividing each category by the number of months. Simple but might be valuable to the users  